### PR TITLE
add move bounds for cursor on example of view

### DIFF
--- a/examples/view/main.go
+++ b/examples/view/main.go
@@ -23,9 +23,13 @@ func app(_ context.Context, es goban.Events) error {
 		goban.Show()
 		switch k := es.ReadKey(); k.Key() {
 		case tcell.KeyUp:
-			v.cursor--
+			if v.cursor > 0 {
+				v.cursor--
+			}
 		case tcell.KeyDown:
-			v.cursor++
+			if v.cursor < len(v.items)-1 {
+				v.cursor++
+			}
 		}
 	}
 }


### PR DESCRIPTION
Hi, I'm trying your great library. Feel very good to me! 😋 

An example of moving cursor (`example/view`) seems infinitely increase/decrease its position even if it is out of bounds of items. This pr aims the cursor not to go out of bounds of items.

I'm happy if this help to improve your example! Thanks in advance! 😆 